### PR TITLE
update gentoo-portage help

### DIFF
--- a/help/gentoo-portage.txt
+++ b/help/gentoo-portage.txt
@@ -2,8 +2,22 @@
 =====收录架构=====
 =====收录版本=====
 =====使用说明=====
-在/etc/portage/make.conf中添加或修改：
-  SYNC="rsync://mirrors.ustc.edu.cn/gentoo-portage"
+旧的 SYNC 方式已不推荐使用，建议使用新的 repos.conf \\
+官网wiki：https://wiki.gentoo.org/wiki//etc/portage/repos.conf
+
+==== 单文件方式 ====
+新建或修改 /etc/portage/repos.conf ：
+<file txt /etc/portage/repos.conf>
+[DEFAULT]
+main-repo = gentoo
+
+[gentoo]
+location = /usr/portage
+sync-type = rsync
+sync-uri = rsync://rsync.mirrors.ustc.edu.cn/gentoo-portage/
+auto-sync = yes
+</file>
+
 =====相关链接=====
 官方主页: http://www.gentoo.org/ \\
 邮件列表: http://www.gentoo.org/main/en/lists.xml \\


### PR DESCRIPTION
should use repos.conf instead of SYNC

reference: https://wiki.gentoo.org/wiki/SYNC

Please check syntax! I am not familiar with LUG syntax. :)