### PR TITLE
fix(Homebrew): Update the Homebrew help doc for upstream change

### DIFF
--- a/help/brew.git.txt
+++ b/help/brew.git.txt
@@ -1,5 +1,5 @@
 ====== 替换homebrew默认源 ======
 <code>
-cd /usr/local
+cd "$(brew --repo)"
 git remote set-url origin git://mirrors.ustc.edu.cn/brew.git
 </code>

--- a/help/homebrew-core.git.txt
+++ b/help/homebrew-core.git.txt
@@ -6,6 +6,6 @@ homebrew-core是Homebrew的核心软件仓库，收录了大部分的常用软�
 在终端中执行以下命令：
 
 <code>
-cd /usr/local/Library/Taps/homebrew/homebrew-core
+cd "$(brew --repo)/Library/Taps/homebrew/homebrew-core"
 git remote set-url origin git://mirrors.ustc.edu.cn/homebrew-core.git
 </code>


### PR DESCRIPTION
Update the Homebrew mirror setting doc due to the upstream change the dir of Homebrew repo.
The migrate issue is [here](https://github.com/Homebrew/brew/issues/987).