### PR TITLE
refactor(homebrew): Collect the help doc in one place

### DIFF
--- a/help/brew.git.txt
+++ b/help/brew.git.txt
@@ -12,7 +12,9 @@ git remote set-url origin https://mirrors.ustc.edu.cn/homebrew-core.git
 替换Homebrew Bottles源:
 参考:[[https://lug.ustc.edu.cn/wiki/mirrors/help/homebrew-bottles|替换Homebrew Bottles源]]
 
-在科大mirror失效或宕机时切回官方源：
+在中科大源失效或宕机时可以：
+1. 使用[[https://mirrors.tuna.tsinghua.edu.cn/help/homebrew/|清华源设置参考]]。
+2. 切换回官方源：
 <code>
 重置brew.git:
 cd "$(brew --repo)"

--- a/help/brew.git.txt
+++ b/help/brew.git.txt
@@ -1,5 +1,27 @@
-====== 替换homebrew默认源 ======
+====== 替换及重置Homebrew默认源 ======
 <code>
+替换brew.git:
 cd "$(brew --repo)"
-git remote set-url origin git://mirrors.ustc.edu.cn/brew.git
+git remote set-url origin https:://mirrors.ustc.edu.cn/brew.git
+
+替换homebrew-core.git:
+cd "$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+git remote set-url origin https://mirrors.ustc.edu.cn/homebrew-core.git
 </code>
+
+替换Homebrew Bottles源:
+参考:[[https://lug.ustc.edu.cn/wiki/mirrors/help/homebrew-bottles|替换Homebrew Bottles源]]
+
+在科大mirror失效或宕机时切回官方源：
+<code>
+重置brew.git:
+cd "$(brew --repo)"
+git remote set-url origin https://github.com/Homebrew/brew.git
+
+重置homebrew-core.git:
+cd "$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+git remote set-url origin https://github.com/Homebrew/homebrew-core.git
+</code>
+
+注释掉bash配置文件里的有关Homebrew Bottles即可恢复官方源。
+重启bash或让bash重读配置文件。

--- a/help/homebrew-core.git.txt
+++ b/help/homebrew-core.git.txt
@@ -2,10 +2,4 @@
 homebrew-core是Homebrew的核心软件仓库，收录了大部分的常用软件。
 
 ## 使用方法
-
-在终端中执行以下命令：
-
-<code>
-cd "$(brew --repo)/Library/Taps/homebrew/homebrew-core"
-git remote set-url origin git://mirrors.ustc.edu.cn/homebrew-core.git
-</code>
+[[请参考：https://lug.ustc.edu.cn/wiki/mirrors/help/brew.git|替换和重置Homebrew源]]


### PR DESCRIPTION
1. Collect the Homebrew help doc in one place except bottle setting.

2. Replace the git to https for efficiency and security.

3. Add the reset method avoiding the ustc mirror break(It is git can't connect now).

4. Need review for the doc format after the transfer through tools.  