### PR TITLE
Remove siglevel from archlinuxcn mirror config

### DIFF
--- a/help/archlinuxcn.txt
+++ b/help/archlinuxcn.txt
@@ -16,7 +16,6 @@ Arch Linux 中文社区仓库是由 Arch Linux 中文社区驱动的非官方用
 
 ```
 [archlinuxcn]
-SigLevel = Optional TrustedOnly
 Server = https://mirrors.ustc.edu.cn/archlinuxcn/$arch
 ```
 


### PR DESCRIPTION
> since all packages are signed, default value for SigLevel (Required DatabaseOptional) is better. 
-- lilydjwg

see also: archlinuxcn/repo#218
