### PR TITLE
修复dockerhub URL

### DIFF
--- a/source/dockerhub.rst
+++ b/source/dockerhub.rst
@@ -5,7 +5,7 @@ Docker Hub 源使用帮助
 地址
 ====
 
-https://mirrors.ustc.edu.cn/dockerhub
+https://mirrors.ustc.edu.cn/dockerhub/
 
 说明
 ====
@@ -23,7 +23,7 @@ Linux
 ::
 
     {
-      "registry-mirrors": ["https://mirrors.ustc.edu.cn/dockerhub"]
+      "registry-mirrors": ["https://mirrors.ustc.edu.cn/dockerhub/"]
     }
 
 重新启动dockerd：
@@ -38,7 +38,7 @@ macOS
 1. 打开 "Docker.app"
 2. 进入偏好设置页面(快捷键 ``⌘,`` )
 3. 打开 "Advanced" 选项卡
-4. 在 "Registry mirrors" 中添加 ``https://mirrors.ustc.edu.cn/dockerhub``
+4. 在 "Registry mirrors" 中添加 ``https://mirrors.ustc.edu.cn/dockerhub/``
 5. 点击下方的 "Restart" 按钮
 
 Windows


### PR DESCRIPTION
如果base URL是  `mirrors.u.e.c/dockerhub` ，则最终会访问 `mirrors.u.e.c/v2/xxxx`

因此需要在`mirrors.u.e.c/dockerhub` 后加一个`/`