### PR TITLE
在Debian Multimedia 源使用帮助中添加导入deb-multimedia-keyring的操作说明。

### DIFF
--- a/source/debian-multimedia.rst
+++ b/source/debian-multimedia.rst
@@ -41,7 +41,10 @@ Debian Old Stable, Stable, Testing, Unstable(sid)
     deb http://mirrors.ustc.edu.cn/debian-multimedia/ jessie-backports main
     # deb-src http://mirrors.ustc.edu.cn/debian-multimedia/ jessie-backports main
 
-更改完 :file:`sources.list` 文件后请运行 ``sudo apt-get update`` 更新索引以生效。
+更改完 :file:`sources.list` 文件后请导入deb-multimedia-keyring
+    wget https://mirrors.ustc.edu.cn/deb-multimedia/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb
+    sudo dpkg -i deb-multimedia-keyring_2016.8.1_all.deb
+然后请运行 ``sudo apt-get update`` 更新索引以生效。
 
 .. tip::
     使用 HTTPS 可以有效避免国内运营商的缓存劫持，但需要事先安装 ``apt-transport-https``

--- a/source/debian-multimedia.rst
+++ b/source/debian-multimedia.rst
@@ -42,8 +42,12 @@ Debian Old Stable, Stable, Testing, Unstable(sid)
     # deb-src http://mirrors.ustc.edu.cn/debian-multimedia/ jessie-backports main
 
 更改完 :file:`sources.list` 文件后请导入deb-multimedia-keyring
+
+::
+
     wget https://mirrors.ustc.edu.cn/deb-multimedia/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2016.8.1_all.deb
     sudo dpkg -i deb-multimedia-keyring_2016.8.1_all.deb
+    
 然后请运行 ``sudo apt-get update`` 更新索引以生效。
 
 .. tip::


### PR DESCRIPTION
使用Debian Multimedia 需要导入deb-multimedia-keyring，否则会报数字签名错误。
在Debian Multimedia 源使用帮助中添加导入deb-multimedia-keyring的操作说明。