### PR TITLE
[fix] fix ubuntu tips format errors

### DIFF
--- a/source/ubuntu.rst
+++ b/source/ubuntu.rst
@@ -54,8 +54,8 @@ AMD64 (x86_64), Intel x86
 
   sudo sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
   
-  .. tip::
-    如果你在安装时选择的语言不是英语，默认的源地址通常不是 ``http://archive.ubuntu.com/`` ，而是 ``http://<country-code>.archive.ubuntu.com/ubuntu/`` 例如： ``http://cn.archive.ubuntu.com/ubuntu/`` ，此时秩序将上面的命令进行相应的替换即可，如： `` sudo sed -i 's/cn.archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list`` 。
+.. tip::
+    如果你在安装时选择的语言不是英语，默认的源地址通常不是 ``http://archive.ubuntu.com/`` ，而是 ``http://<country-code>.archive.ubuntu.com/ubuntu/`` 例如： ``http://cn.archive.ubuntu.com/ubuntu/`` ，此时只需将上面的命令进行相应的替换即可，如： `` sudo sed -i 's/cn.archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list`` 。
 
 当然也可以直接编辑 :file:`/etc/apt/sources.list` 文件（需要使用 sudo）。以下是 Ubuntu 16.04 参考配置内容：
 


### PR DESCRIPTION
修改 ubuntu 帮助文档中 tips 的格式错误与里面的错别字。