### PR TITLE
修正archive.raspberrypi.org 镜像源说明中的错误

### DIFF
--- a/source/archive.raspberrypi.org.rst
+++ b/source/archive.raspberrypi.org.rst
@@ -34,6 +34,7 @@ https://mirrors.ustc.edu.cn/archive.raspberrypi.org/
 
 .. warning::
     操作前请做好相应备份
+    
     老的地址 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org`` 已经不可用，请切换至     ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian`` 后更新
 
 一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/``

--- a/source/archive.raspberrypi.org.rst
+++ b/source/archive.raspberrypi.org.rst
@@ -34,15 +34,16 @@ https://mirrors.ustc.edu.cn/archive.raspberrypi.org/
 
 .. warning::
     操作前请做好相应备份
+    老的地址 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org`` 已经不可用，请切换至     ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian`` 后更新
 
 一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/``
-替换为 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/`` 即可。
+替换为 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian`` 即可。
 
 可以使用如下命令：
 
 ::
 
-  sudo sed -i 's|//archive.raspberrypi.org|//mirrors.ustc.edu.cn/archive.raspberrypi.org|g' /etc/apt/sources.list.d/raspi.list
+  sudo sed -i 's|//archive.raspberrypi.org|//mirrors.ustc.edu.cn/archive.raspberrypi.org/debian|g' /etc/apt/sources.list.d/raspi.list
 
 当然也可以直接编辑 :file:`/etc/apt/sources.list.d/raspi.list` 文件（需要使用 sudo）。以下是 Stretch 的参考配置内容：
 

--- a/source/archive.raspberrypi.org.rst
+++ b/source/archive.raspberrypi.org.rst
@@ -34,17 +34,15 @@ https://mirrors.ustc.edu.cn/archive.raspberrypi.org/
 
 .. warning::
     操作前请做好相应备份
-    
-    老的地址 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org`` 已经不可用，请切换至     ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian`` 后更新
 
-一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/``
+一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/debian``
 替换为 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian`` 即可。
 
 可以使用如下命令：
 
 ::
 
-  sudo sed -i 's|//archive.raspberrypi.org|//mirrors.ustc.edu.cn/archive.raspberrypi.org/debian|g' /etc/apt/sources.list.d/raspi.list
+  sudo sed -i 's|//archive.raspberrypi.org/debian|//mirrors.ustc.edu.cn/archive.raspberrypi.org/debian|g' /etc/apt/sources.list.d/raspi.list
 
 当然也可以直接编辑 :file:`/etc/apt/sources.list.d/raspi.list` 文件（需要使用 sudo）。以下是 Stretch 的参考配置内容：
 


### PR DESCRIPTION
镜像地址更新后说明文档中没有同步更新完，修正说明文档