### PR TITLE
add empty `insecure-registries` in daemon.json

### DIFF
--- a/source/dockerhub.rst
+++ b/source/dockerhub.rst
@@ -35,13 +35,14 @@ Linux
 ::
 
     {
-      "registry-mirrors": ["https://docker.mirrors.ustc.edu.cn/"]
+      "registry-mirrors": ["https://docker.mirrors.ustc.edu.cn/"],
+      "insecure-registries": []
     }
 
 重新启动 dockerd：
 
 ::
-
+  sudo systemctl daemon-reload
   sudo systemctl restart docker
 
 macOS


### PR DESCRIPTION
It only takes effect after add `insecure-registries`
OS version "Ubuntu 16.04.4 LTS"
Docker version 18.09.2, build 6247962