### PR TITLE
brew.git: use git insteadOf to replace urls in install.sh

### DIFF
--- a/source/brew.git.rst
+++ b/source/brew.git.rst
@@ -38,15 +38,13 @@ Homebrew 源代码仓库
     如有需要，脚本中的 ``HOMEBREW_CORE_GIT_REMOTE`` 变量可以修改为 :doc:`homebrew-core.git` 
     (macOS) 或 :doc:`linuxbrew-core.git` (Linux) 中对应的地址，以加快核心软件仓库索引下载的速度。
 
-    由于 brew 安装脚本此前多次修改相关的变量名，也可以参考以下命令，将脚本中所有需要访问 GitHub 的 URL 替换为科大源:
+    由于 brew 安装脚本此前多次修改相关的变量名，也可以参考以下命令，让 Git 将脚本访问的所有 GitHub 的 URL 替换为科大源:
 
     ::
 
-        sed -e 's|https://github.com/Homebrew/homebrew-core|https://mirrors.ustc.edu.cn/homebrew-core.git|g' \
-            -e 's|https://github.com/Homebrew/linuxbrew-core|https://mirrors.ustc.edu.cn/linuxbrew-core.git|g' \
-            -e 's|https://github.com/Homebrew/brew|https://mirrors.ustc.edu.cn/brew.git|g' \
-            -i.bak \
-            install.sh
+        git config --global url."https://mirrors.ustc.edu.cn/homebrew-core.git".insteadOf "https://github.com/Homebrew/homebrew-core"
+        git config --global url."https://mirrors.ustc.edu.cn/linuxbrew-core.git".insteadOf "https://github.com/Homebrew/linuxbrew-core"
+        git config --global url."https://mirrors.ustc.edu.cn/brew.git".insteadOf "https://github.com/Homebrew/brew"
         chmod +x install.sh
         # macOS
         HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles ./install.sh

--- a/source/brew.git.rst
+++ b/source/brew.git.rst
@@ -50,6 +50,10 @@ Homebrew 源代码仓库
         HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles ./install.sh
         # Linux
         HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles ./install.sh
+        # 在安装完成后，取消 git 的 insteadOf 配置
+        git config --global --unset url."https://mirrors.ustc.edu.cn/homebrew-core.git".insteadOf
+        git config --global --unset url."https://mirrors.ustc.edu.cn/linuxbrew-core.git".insteadOf
+        git config --global --unset url."https://mirrors.ustc.edu.cn/brew.git".insteadOf
 
 相关镜像
 ========

--- a/source/brew.git.rst
+++ b/source/brew.git.rst
@@ -38,6 +38,15 @@ Homebrew 源代码仓库
     如有需要，脚本中的 ``HOMEBREW_CORE_GIT_REMOTE`` 变量可以修改为 :doc:`homebrew-core.git` 
     (macOS) 或 :doc:`linuxbrew-core.git` (Linux) 中对应的地址，以加快核心软件仓库索引下载的速度。
 
+    由于 brew 安装脚本此前多次修改相关的变量名，也可以参考以下命令，将脚本中所有需要访问 GitHub 的 URL 替换为科大源:
+
+    ::
+
+        sed -e 's|https://github.com/Homebrew/homebrew-core|https://mirrors.ustc.edu.cn/homebrew-core.git|g' \
+            -e 's|https://github.com/Homebrew/linuxbrew-core|https://mirrors.ustc.edu.cn/linuxbrew-core.git|g' \
+            -e 's|https://github.com/Homebrew/brew|https://mirrors.ustc.edu.cn/brew.git|g' \
+            -i.bak \
+            install.sh
 
 相关镜像
 ========

--- a/source/brew.git.rst
+++ b/source/brew.git.rst
@@ -47,6 +47,11 @@ Homebrew 源代码仓库
             -e 's|https://github.com/Homebrew/brew|https://mirrors.ustc.edu.cn/brew.git|g' \
             -i.bak \
             install.sh
+        chmod +x install.sh
+        # macOS
+        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles ./install.sh
+        # Linux
+        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles ./install.sh
 
 相关镜像
 ========


### PR DESCRIPTION
这么写 `sed` 是因为 brew 的安装脚本中的变量名变了好几次，并且 brew 他们也不打算配置成可以使用环境变量配置上游的方式。与其跟着 brew 脚本里面改变量名一直改帮助，不如把 URL 直接替换掉……

不太清楚这么写合不合适，所以交个 PR 看看（