### PR TITLE
brew v3.0.7开始,HOMEBREW_BOTTLE_DOMAIN需要指定到/bottles这一级路径

### DIFF
--- a/source/brew.git.rst
+++ b/source/brew.git.rst
@@ -47,9 +47,9 @@ Homebrew 源代码仓库
         git config --global url."https://mirrors.ustc.edu.cn/brew.git".insteadOf "https://github.com/Homebrew/brew"
         chmod +x install.sh
         # macOS
-        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles ./install.sh
+        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles/bottles ./install.sh
         # Linux
-        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles ./install.sh
+        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles/bottles ./install.sh
 
     初次安装完成后，若想从 GitHub 官方仓库获取后续更新，需要恢复上面步骤中修改过的 ``git config``：
 

--- a/source/homebrew-bottles.rst
+++ b/source/homebrew-bottles.rst
@@ -5,7 +5,7 @@ Homebrew Bottles 源使用帮助
 地址
 ====
 
-https://mirrors.ustc.edu.cn/homebrew-bottles/
+https://mirrors.ustc.edu.cn/homebrew-bottles/bottles/
 
 说明
 ====
@@ -20,20 +20,20 @@ Homebrew 预编译二进制软件包
 使用说明
 ========
 
-请在运行 brew 前设置环境变量 ``HOMEBREW_BOTTLE_DOMAIN`` ，值为 ``https://mirrors.ustc.edu.cn/homebrew-bottles`` 。
+请在运行 brew 前设置环境变量 ``HOMEBREW_BOTTLE_DOMAIN`` ，值为 ``https://mirrors.ustc.edu.cn/homebrew-bottles/bottles`` 。
 
 对于 bash 用户：
 
 ::
 
-    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles' >> ~/.bash_profile
+    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles/bottles' >> ~/.bash_profile
     source ~/.bash_profile
 
 对于 zsh 用户：
 
 ::
 
-    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles' >> ~/.zshrc
+    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles/bottles' >> ~/.zshrc
     source ~/.zshrc
 
 相关镜像

--- a/source/linuxbrew-bottles.rst
+++ b/source/linuxbrew-bottles.rst
@@ -5,7 +5,7 @@ Linuxbrew Bottles 源使用帮助
 地址
 ====
 
-https://mirrors.ustc.edu.cn/linuxbrew-bottles/
+https://mirrors.ustc.edu.cn/linuxbrew-bottles/bottles/
 
 说明
 ====
@@ -20,20 +20,20 @@ Linuxbrew 预编译二进制软件包
 使用说明
 ========
 
-请在运行 brew 前设置环境变量 ``HOMEBREW_BOTTLE_DOMAIN`` ，值为 ``https://mirrors.ustc.edu.cn/linuxbrew-bottles`` 。
+请在运行 brew 前设置环境变量 ``HOMEBREW_BOTTLE_DOMAIN`` ，值为 ``https://mirrors.ustc.edu.cn/linuxbrew-bottles/bottles`` 。
 
 对于 bash 用户：
 
 ::
 
-    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles' >> ~/.bash_profile
+    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles/bottles' >> ~/.bash_profile
     source ~/.bash_profile
 
 对于 zsh 用户：
 
 ::
 
-    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles' >> ~/.zshrc
+    echo 'export HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/linuxbrew-bottles/bottles' >> ~/.zshrc
     source ~/.zshrc
 
 相关镜像


### PR DESCRIPTION
参考[brew Release 3.0.7发布内容](https://github.com/Homebrew/brew/releases/tag/3.0.7)的参考，去除了对`/bottles`这级路径的拼接，因此目前得类似：`HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles/bottles`如此。

参考：

 - [github_packages: fix HOMEBREW_BOTTLE_DOMAIN usage. ](https://github.com/Homebrew/brew/pull/10863)
