### PR TITLE
opensuse, packman: use $releasever in repository url 

### DIFF
--- a/source/opensuse.rst
+++ b/source/opensuse.rst
@@ -32,18 +32,24 @@ i586, x86_64
 
   sudo zypper mr -da
 
-添加科大镜像源，以 openSUSE Leap 42.3 为例：
+添加科大镜像源，以 openSUSE Leap 为例：
 
 ::
 
-  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/distribution/leap/42.3/repo/oss USTC:42.3:OSS
-  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/distribution/leap/42.3/repo/non-oss USTC:42.3:NON-OSS
-  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/update/leap/42.3/oss USTC:42.3:UPDATE-OSS
-  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/update/leap/42.3/non-oss USTC:42.3:UPDATE-NON-OSS
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/distribution/leap/\$releasever/repo/oss USTC:OSS
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/distribution/leap/\$releasever/repo/non-oss USTC:NON-OSS
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/update/leap/\$releasever/oss USTC:UPDATE-OSS
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/update/leap/\$releasever/non-oss USTC:UPDATE-NON-OSS
+
+对于 15.3 或更高版本的 openSUSE Leap，还需添加 SLE 更新源：
+
+::
+
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/opensuse/update/leap/\$releasever/sle USTC:UPDATE-SLE
 
 命令中最后一个参数为每一个源指定了一个 alias （别称），可以根据个人喜好更改。
 
-手动刷新软件源
+手动刷新软件源：
 
 ::
 
@@ -52,22 +58,22 @@ i586, x86_64
 图形界面下配置方法
 -------------------
 
-以 openSUSE Leap 42.3 为例：
+以 openSUSE Leap 15.3 为例：
 
 #. 打开 YaST；
 #. 点击 Software 分组中的 Software Repositories；
-#. 在打开的窗口上方的列表中点击 openSUSE-Leap-42.3-Oss ，点击 Edit；
-#. 将 download.opensuse.org 替换为 mirrors.ustc.edu.cn/opensuse，点OK；
-#. 再用同样的方法编辑 openSUSE-Leap-42.3-Oss 和 openSUSE-Leap-42.3-Oss。
+#. 在打开的窗口上方的列表中点击 Main Repository，点击 Edit；
+#. 将 download.opensuse.org 替换为 mirrors.ustc.edu.cn/opensuse，点 OK；
+#. 再用同样的方法编辑 Non-OSS Repository, Main Update Repository, Update Repository (Non-Oss) 和 Update repository with updates from SUSE Linux Enterprise 15。
 
 注意事项
 ========
 
-* 由于使用了 MirrorBrain 技术， 中央服务器 (download.opensuse.org) 会按照 IP
+* 由于使用了 MirrorBrain 技术，中央服务器 (download.opensuse.org) 会按照 IP
   地理位置中转下载请求到附近的镜像服务器（但刷新软件源时仍从中央服务器获取
   元数据），所以更改软件源通常只会加快刷新软件源的速度，而对下载速度影响不大。
   参见 `openSUSE 中文论坛 <https://forum.suse.org.cn/t/opensuse/1759>`_ 。
-* 我们不提供 source 和 debug 源。
+* 我们不提供 backports, source 和 debug 源。
 * Tumbleweed 滚动发行版软件源的地址与上述例子稍有不同。
 
 相关链接

--- a/source/packman.rst
+++ b/source/packman.rst
@@ -21,11 +21,11 @@ openSUSE 非官方社区软件源，主要收录允许自由分发但存在专�
 使用说明
 ========
 
-以 openSUSE Leap 42.3 为例添加软件源：
+以 openSUSE Leap 为例添加软件源：
 
 ::
 
-  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/packman/suse/openSUSE_Leap_42.3/ USTC:42.3:PACKMAN
+  sudo zypper ar -fcg https://mirrors.ustc.edu.cn/packman/suse/openSUSE_Leap_\$releasever/ USTC:PACKMAN
 
 相关链接
 ========


### PR DESCRIPTION
主要改动如题，根据 [Wiki](https://en.opensuse.org/SDB:System_upgrade#5._Update_the_repos) 作如此替换，新装的系统中也是默认使用 `$releasever` 的。

另外 openSUSE 配置那里把 USTC:UPDATE-SLE 加上了。

另外由于 [Backports](https://mirrors.ustc.edu.cn/opensuse/update/leap/15.3/backports/) 是默认启用的，科大没有镜像这个仓库，在 openSUSE「注意事项」部分添加了说明。

> Note 1: openSUSE「图形界面下配置方法」部分的 Non-***OSS*** Repository 跟 Update Repository (Non-***Oss)*** 中的 OSS 大小写默认就是这样的。

> Note 2: 以上所有标有「默认」的地方均参照了 openSUSE-Leap-15.3-GNOME-Live-x86_64-Build9.108-Media.iso。

感谢抽出时间 review 这个 PR！

off-topic: [ustclug/opensuse-guide](https://github.com/ustclug/opensuse-guide) 可能需要更新一下。