### PR TITLE
fix debian 11 security archive layout

### DIFF
--- a/source/raspbian.rst
+++ b/source/raspbian.rst
@@ -62,8 +62,8 @@ Arm64 架构的 Raspberry Pi OS 仍处于 beta 状态，本镜像上游亦不含
     # deb-src http://mirrors.ustc.edu.cn/debian bullseye main contrib non-free
     deb https://mirrors.ustc.edu.cn/debian/ bullseye-updates main contrib non-free
     # deb-src http://mirrors.ustc.edu.cn/debian bullseye-updates main contrib non-free
-    deb https://mirrors.ustc.edu.cn/debian-security bullseye/updates main contrib non-free
-    # deb-src http://mirrors.ustc.edu.cn/debian-security/ bullseye/updates main non-free contrib
+    deb https://mirrors.ustc.edu.cn/debian-security bullseye-security main contrib non-free
+    # deb-src http://mirrors.ustc.edu.cn/debian-security/ bullseye-security main non-free contrib
 
 编辑此文件后，请使用 ``sudo apt-get update`` 命令，更新软件索引。
 


### PR DESCRIPTION
"5.1.3. Changed security archive layout
For bullseye, the security suite is now named bullseye-security instead of codename/updates and users should adapt their APT source-list files accordingly when upgrading.

The security line in your APT configuration may look like:

deb https://deb.debian.org/debian-security bullseye-security main contrib"