### PR TITLE
nix-channels: add instructions for NixOS 22.05

### DIFF
--- a/source/nix-channels.rst
+++ b/source/nix-channels.rst
@@ -42,19 +42,30 @@ NixOS channel 也可以以类似命令替换，以 ``nixos-19.09`` 为例（需�
 
     substituters = https://mirrors.ustc.edu.cn/nix-channels/store https://cache.nixos.org/
 
-对于 NixOS 21.11 及之前的版本与 nix-darwin：
+对于 NixOS 和 nix-darwin，需要编辑 NixOS / nix-darwin 配置文件，系统会自动生成对应的 ``/etc/nix/nix.conf`` 文件。
+
+.. attention::
+    如果你手动指定了 ``NIX_PATH`` 或是使用 Flakes 管理系统，请根据具体情况编辑对应的文件，以下仅供参考。
+
+对于 nix-darwin，在 ``~/.nixpkgs/darwin-configuration.nix`` 中添加：
 
 ::
 
     nix.binaryCaches = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
 
-对于 NixOS 22.05 及之后的版本：
+对于 NixOS 21.11 及之前的版本，在 ``/etc/nixos/configuration.nix`` 中添加：
+
+::
+
+    nix.binaryCaches = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
+
+对于 NixOS 22.05 及之后的版本，在 ``/etc/nixos/configuration.nix`` 中添加：
 
 ::
 
     nix.settings.substituters = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
 
-.. tip::
+.. note::
     对于所有 NixOS 19.09 及之后的版本和 nix-darwin， ``"https://cache.nixos.org/"`` 会被自动添加到配置中。
 
 本帮助参考了 `TUNA 的 nix 帮助 <https://mirrors.tuna.tsinghua.edu.cn/help/nix/>`_ 编写。

--- a/source/nix-channels.rst
+++ b/source/nix-channels.rst
@@ -42,14 +42,20 @@ NixOS channel 也可以以类似命令替换，以 ``nixos-19.09`` 为例（需�
 
     substituters = https://mirrors.ustc.edu.cn/nix-channels/store https://cache.nixos.org/
 
-对于 NixOS 与 nix-darwin：
+对于 NixOS 21.11 及之前的版本与 nix-darwin：
 
 ::
 
-    nix.binaryCaches = [ "https://mirrors.ustc.edu.cn/nix-channels/store" "https://cache.nixos.org/" ];
+    nix.binaryCaches = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
+
+对于 NixOS 22.05 及之后的版本：
+
+::
+
+    nix.settings.substituters = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
 
 .. tip::
-    如果使用 NixOS 19.09 之后的版本和 nix-darwin，配置中的 ``"https://cache.nixos.org/"`` 可以省略。
+    对于所有 NixOS 19.09 及之后的版本和 nix-darwin， ``"https://cache.nixos.org/"`` 会被自动添加到配置中。
 
 本帮助参考了 `TUNA 的 nix 帮助 <https://mirrors.tuna.tsinghua.edu.cn/help/nix/>`_ 编写。
 


### PR DESCRIPTION
- NixOS 19.03 及之前的版本都 [EOL 至少两年了](https://endoflife.date/nixos)，从示例配置中删除了 `"https://cache.nixos.org/"`。
- https://github.com/NixOS/nixpkgs/commit/4a9d9928dc01421b878cfe4a16961c1e4862d846 起 NixOS 配置 binary cache 就需要使用 `nix.settings.substituters` 了。
- nix-darwin [依然](https://github.com/LnL7/nix-darwin/blob/bb3baef6e115ae47bc2ab4973bd3a486488485b0/modules/nix/default.nix#L231-L238) 使用的是 `nix.binaryCaches`。