### PR TITLE
Update msys2: unified mingw mirror list change

### DIFF
--- a/source/msys2.rst
+++ b/source/msys2.rst
@@ -26,30 +26,17 @@ MSYS2镜像
 pacman的配置
 ============
 
-编辑 :file:`/etc/pacman.d/mirrorlist.mingw32` ，在文件开头添加：
+编辑 :file:`/etc/pacman.d/mirrorlist.mingw` ，在文件开头添加：
 
 ::
     
-    Server = http://mirrors.ustc.edu.cn/msys2/mingw/i686   
-
-
-编辑 :file:`/etc/pacman.d/mirrorlist.mingw64` ，在文件开头添加
-
-::
-
-    Server = http://mirrors.ustc.edu.cn/msys2/mingw/x86_64
+    Server = https://mirrors.ustc.edu.cn/msys2/mingw/$repo
 
 编辑 :file:`/etc/pacman.d/mirrorlist.msys` ，在文件开头添加
 
 ::
 
     Server = http://mirrors.ustc.edu.cn/msys2/msys/$arch
-
-编辑 :file:`/etc/pacman.d/mirrorlist.ucrt64` ，在文件开头添加
-
-::
-
-    Server = http://mirrors.ustc.edu.cn/msys2/mingw/ucrt64
 
 然后执行 ``pacman -Sy`` 刷新软件包数据即可。
 


### PR DESCRIPTION
https://github.com/msys2/MSYS2-packages/commit/cfdb662d9859a21174afa3c9c3d1eb9ec1d98727

MSYS2 pacman.conf 已经为 MinGW 相关仓库（mingw32、mingw64、ucrt64、clang64，以及此后添加的 clang32、clangarm64）使用统一的配置文件。