### PR TITLE
Update archlinuxarm.rst, remove armv5 and armv6 architecture

### DIFF
--- a/source/archlinuxarm.rst
+++ b/source/archlinuxarm.rst
@@ -15,7 +15,7 @@ Arch Linux ARM 软件源
 收录架构
 ========
 
-ARMv5, ARMv6, ARMv7, AArch64
+ARMv7, AArch64
 
 使用说明
 ========


### PR DESCRIPTION
Arch Linux ARM 已停止支持 ARMv5 和 ARMv6，见 https://archlinuxarm.org/forum/viewtopic.php?f=3&t=15721