### PR TITLE
fix(crates.io-index): fix config file path error when install rust without default CARGO_HOME environment variable

### DIFF
--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -37,7 +37,7 @@ Rust Crates Registry 源
         [source.ustc]
         registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
 
-    可以使用下面的命令完成 
+    在 Linux 环境可以使用下面的命令完成
 
     ::
 
@@ -62,7 +62,7 @@ Rust Crates Registry 源
     [source.ustc]
     registry = "git://mirrors.ustc.edu.cn/crates.io-index"
 
-可以使用下面的命令完成
+在 Linux 环境可以使用下面的命令完成
 
 ::
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -52,7 +52,7 @@ Rust Crates Registry 源
         EOF
 
 
-在 :file:`$CARGO_HOME/config.toml` 中添加如下内容：
+在 :file:`$CARGO_HOME/config` 中添加如下内容：
 
 ::
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -19,6 +19,7 @@ Rust Crates Registry 源
 
 .. note::
     Windows 系统默认路径为: `%USERPROFILE%\.cargo\config`
+    
     类 Unix 系统默认路径为: `$HOME/.cargo/config` 
 
 ::

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -27,7 +27,7 @@ Rust Crates Registry 源
         check-revoke = false
 
 .. note::
-    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$HOME/.cargo/config` 中添加如下内容：
+    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config.toml` 中添加如下内容：
 
     ::
 
@@ -37,7 +37,22 @@ Rust Crates Registry 源
         [source.ustc]
         registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
 
-在 :file:`$HOME/.cargo/config` 中添加如下内容：
+    可以使用下面的命令完成 
+
+    ::
+
+        mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
+
+        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
+        [source.crates-io]
+        replace-with = 'ustc'
+
+        [source.ustc]
+        registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
+        EOF
+
+
+在 :file:`$CARGO_HOME/config.toml` 中添加如下内容：
 
 ::
 
@@ -46,6 +61,20 @@ Rust Crates Registry 源
 
     [source.ustc]
     registry = "git://mirrors.ustc.edu.cn/crates.io-index"
+
+可以使用下面的命令完成
+
+::
+
+    mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
+
+    cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
+    [source.crates-io]
+    replace-with = 'ustc'
+
+    [source.ustc]
+    registry = "git://mirrors.ustc.edu.cn/crates.io-index"
+    EOF
 
 如果所处的环境中不允许使用 git 协议，可以把上述地址改为：
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -27,7 +27,7 @@ Rust Crates Registry 源
         check-revoke = false
 
 .. note::
-    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` 中添加如下内容：
+    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` ( Windows 系统默认路径为: `%USERPROFILE%\.cargo\config` ,类 Unix 系统默认路径为: `$HOME/.cargo/config` )中添加如下内容：
 
     ::
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -15,44 +15,11 @@ Rust Crates Registry 源
 使用说明
 ========
 
-.. warning::
-    若使用 crates 源时出现 :code:`Couldn't resolve host name (Could not resolve host: crates)` 错误（见 https://github.com/ustclug/discussions/issues/294），可能需要在运行 :code:`cargo` 的时候加入环境变量 :code:`CARGO_HTTP_MULTIPLEXING=false`。
-
-.. warning::
-    Windows 用户在使用 crates 源时可能会出现 :code:`next InitializeSecurityContext failed: Unknown error` 错误（见 https://github.com/ustclug/discussions/issues/339 和 https://github.com/rust-lang/cargo/issues/7096）。一个 workaround 是在运行 :code:`cargo` 的时候加入环境变量 :code:`CARGO_HTTP_CHECK_REVOKE=false`，或者在配置中增加：
-
-    ::
-
-        [http]
-        check-revoke = false
+在 :file:`$CARGO_HOME/config` 中添加如下内容：
 
 .. note::
-    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` ( Windows 系统默认路径为: `%USERPROFILE%\.cargo\config` ,类 Unix 系统默认路径为: `$HOME/.cargo/config` )中添加如下内容：
-
-    ::
-
-        [source.crates-io]
-        replace-with = 'ustc'
-
-        [source.ustc]
-        registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
-
-    在 Linux 环境可以使用下面的命令完成
-
-    ::
-
-        mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
-
-        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
-        [source.crates-io]
-        replace-with = 'ustc'
-
-        [source.ustc]
-        registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
-        EOF
-
-
-在 :file:`$CARGO_HOME/config` 中添加如下内容：
+    Windows 系统默认路径为: `%USERPROFILE%\.cargo\config`
+    类 Unix 系统默认路径为: `$HOME/.cargo/config` 
 
 ::
 
@@ -82,8 +49,44 @@ Rust Crates Registry 源
 
     registry = "https://mirrors.ustc.edu.cn/crates.io-index"
 
+.. note::
+    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` 中添加如下内容：
+
+    ::
+
+        [source.crates-io]
+        replace-with = 'ustc'
+
+        [source.ustc]
+        registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
+
+    在 Linux 环境可以使用下面的命令完成
+
+    ::
+
+        mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
+
+        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+        [source.crates-io]
+        replace-with = 'ustc'
+
+        [source.ustc]
+        registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
+        EOF
+
 .. warning::
     ``cargo search`` 无法使用镜像。
+
+.. warning::
+    若使用 crates 源时出现 :code:`Couldn't resolve host name (Could not resolve host: crates)` 错误（见 https://github.com/ustclug/discussions/issues/294），可能需要在运行 :code:`cargo` 的时候加入环境变量 :code:`CARGO_HTTP_MULTIPLEXING=false`。
+
+.. warning::
+    Windows 用户在使用 crates 源时可能会出现 :code:`next InitializeSecurityContext failed: Unknown error` 错误（见 https://github.com/ustclug/discussions/issues/339 和 https://github.com/rust-lang/cargo/issues/7096）。一个 workaround 是在运行 :code:`cargo` 的时候加入环境变量 :code:`CARGO_HTTP_CHECK_REVOKE=false`，或者在配置中增加：
+
+    ::
+
+        [http]
+        check-revoke = false
 
 相关链接
 ========

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -35,7 +35,7 @@ Rust Crates Registry 源
 
         registry = "https://mirrors.ustc.edu.cn/crates.io-index"
 
-在 Linux 环境可以使用下面的命令完成:
+在 Linux 环境可以使用下面的命令完成：
 
 ::
 
@@ -60,7 +60,7 @@ Rust Crates Registry 源
         [source.ustc]
         registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
 
-    在 Linux 环境可以使用下面的命令完成:
+    在 Linux 环境可以使用下面的命令完成：
 
     ::
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -27,7 +27,7 @@ Rust Crates Registry 源
         check-revoke = false
 
 .. note::
-    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config.toml` 中添加如下内容：
+    cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` 中添加如下内容：
 
     ::
 
@@ -43,7 +43,7 @@ Rust Crates Registry 源
 
         mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
+        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
         [source.crates-io]
         replace-with = 'ustc'
 
@@ -68,7 +68,7 @@ Rust Crates Registry 源
 
     mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-    cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
+    cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
     [source.crates-io]
     replace-with = 'ustc'
 

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -17,9 +17,6 @@ Rust Crates Registry 源
 
 在 :file:`$CARGO_HOME/config` 中添加如下内容：
 
-.. note::
-    Windows 系统默认路径为: ``%USERPROFILE%\.cargo\config``，类 Unix 系统默认路径为: ``$HOME/.cargo/config``
-
 ::
 
     [source.crates-io]
@@ -27,6 +24,16 @@ Rust Crates Registry 源
 
     [source.ustc]
     registry = "git://mirrors.ustc.edu.cn/crates.io-index"
+
+.. note::
+    ``$CARGO_HOME`` 在 Windows 系统默认为：``%USERPROFILE%\.cargo``，在类 Unix 系统默认为：``$HOME/.cargo``
+
+.. note::
+    如果所处的环境中不允许使用 git 协议，可以把上述地址改为：
+
+    ::
+
+        registry = "https://mirrors.ustc.edu.cn/crates.io-index"
 
 在 Linux 环境可以使用下面的命令完成:
 
@@ -41,12 +48,6 @@ Rust Crates Registry 源
     [source.ustc]
     registry = "git://mirrors.ustc.edu.cn/crates.io-index"
     EOF
-
-如果所处的环境中不允许使用 git 协议，可以把上述地址改为：
-
-::
-
-    registry = "https://mirrors.ustc.edu.cn/crates.io-index"
 
 .. note::
     cargo 1.68 版本开始支持稀疏索引：不再需要完整克隆 crates.io-index 仓库，可以加快获取包的速度。如果您的 cargo 版本大于等于 1.68，可以在 :file:`$CARGO_HOME/config` 中添加如下内容：

--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -18,9 +18,7 @@ Rust Crates Registry 源
 在 :file:`$CARGO_HOME/config` 中添加如下内容：
 
 .. note::
-    Windows 系统默认路径为: `%USERPROFILE%\.cargo\config`
-    
-    类 Unix 系统默认路径为: `$HOME/.cargo/config` 
+    Windows 系统默认路径为: ``%USERPROFILE%\.cargo\config``，类 Unix 系统默认路径为: ``$HOME/.cargo/config``
 
 ::
 
@@ -30,7 +28,7 @@ Rust Crates Registry 源
     [source.ustc]
     registry = "git://mirrors.ustc.edu.cn/crates.io-index"
 
-在 Linux 环境可以使用下面的命令完成
+在 Linux 环境可以使用下面的命令完成:
 
 ::
 
@@ -61,7 +59,7 @@ Rust Crates Registry 源
         [source.ustc]
         registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
 
-    在 Linux 环境可以使用下面的命令完成
+    在 Linux 环境可以使用下面的命令完成:
 
     ::
 


### PR DESCRIPTION
cargo 安装时，如果没有指定 CARGO_HOME 时，默认的 CARGO_HOME 路径为 `~/.cargo` cargo 的配置文件路径 `$CARGO_HOME/config.toml`, 但是如果用户配置了 CARGO_HOME 环境变量，则配置文件的路径不再是 `~/.cargo/config.toml`，详细内容参见： [The Cargo Book Configuration](https://doc.rust-lang.org/cargo/reference/config.html#configuration)

PR修正了文本中的路径（使用 `$CARGO_HOME/config.toml` 替换 `~/.cargo/config`，原本的配置文件没有`.toml`后缀，不确定之前的文档是否正确）。并增加了 Linux 环境下写入配置文件的命令。