### PR TITLE
fix(crates.io-index): command error

### DIFF
--- a/source/crates.io-index.rst
+++ b/source/crates.io-index.rst
@@ -41,7 +41,7 @@ Rust Crates Registry 源
 
     mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-    cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+    cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
     [source.crates-io]
     replace-with = 'ustc'
 
@@ -66,7 +66,7 @@ Rust Crates Registry 源
 
         mkdir -vp ${CARGO_HOME:-$HOME/.cargo}
 
-        cat << EOF tee -a ${CARGO_HOME:-$HOME/.cargo}/config
+        cat << EOF | tee -a ${CARGO_HOME:-$HOME/.cargo}/config
         [source.crates-io]
         replace-with = 'ustc'
 


### PR DESCRIPTION
抱歉，上一个提交的版本中，tee命令前少了管道符