### PR TITLE
update to bookworm

### DIFF
--- a/source/raspberrypi.rst
+++ b/source/raspberrypi.rst
@@ -39,7 +39,7 @@ https://mirrors.ustc.edu.cn/archive.raspberrypi.org/ 或 https://mirrors.ustc.ed
 .. warning::
     操作前请做好相应备份
 
-一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/`` （bullseye 及之前版本）或者 ``http://archive.raspberrypi.com/`` （bookworm 及之后版本）替换为 ``http://mirrors.ustc.edu.cn/raspberrypi/`` 即可。
+一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/``\ （bullseye 及之前版本）或者 ``http://archive.raspberrypi.com/``\ （bookworm 及之后版本）替换为 ``http://mirrors.ustc.edu.cn/raspberrypi/`` 即可。
 
 可以使用如下命令：
 

--- a/source/raspberrypi.rst
+++ b/source/raspberrypi.rst
@@ -39,20 +39,24 @@ https://mirrors.ustc.edu.cn/archive.raspberrypi.org/ 或 https://mirrors.ustc.ed
 .. warning::
     操作前请做好相应备份
 
-一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/`` 替换为 ``http://mirrors.ustc.edu.cn/archive.raspberrypi.org/`` 即可。
+一般情况下，将 :file:`/etc/apt/sources.list.d/raspi.list` 文件中默认的源地址 ``http://archive.raspberrypi.org/`` （bullseye 及之前版本）或者 ``http://archive.raspberrypi.com/`` （bookworm 及之后版本）替换为 ``http://mirrors.ustc.edu.cn/raspberrypi/`` 即可。
 
 可以使用如下命令：
 
 ::
 
-    sudo sed -i 's|//archive.raspberrypi.org|//mirrors.ustc.edu.cn/archive.raspberrypi.org|g' /etc/apt/sources.list.d/raspi.list
+    sudo sed \
+    -e 's|http://archive.raspberrypi.org|http://mirrors.ustc.edu.cn/raspberrypi|g' \
+    -e 's|http://archive.raspberrypi.com|http://mirrors.ustc.edu.cn/raspberrypi|g' \
+    -i.bak \
+    /etc/apt/sources.list.d/raspi.list
 
-当然也可以直接编辑 :file:`/etc/apt/sources.list.d/raspi.list` 文件（需要使用 sudo）。以下是 Bullseye 的参考配置内容：
+当然也可以直接编辑 :file:`/etc/apt/sources.list.d/raspi.list` 文件（需要使用 sudo）。以下是 bookworm 的参考配置内容：
 
 ::
 
-    deb http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian/ bullseye main ui
-    #deb-src http://mirrors.ustc.edu.cn/archive.raspberrypi.org/debian/ bullseye main ui
+    deb http://mirrors.ustc.edu.cn/raspberrypi/debian/ bookworm main
+    #deb-src http://mirrors.ustc.edu.cn/raspberrypi/debian/ bookworm main
 
 更改完 :file:`raspi.list` 文件后请运行 ``sudo apt-get update`` 更新索引以生效。
 


### PR DESCRIPTION
1. bookworm 的默认源从 `http://archive.raspberrypi.org/` 更换为 `http://archive.raspberrypi.com/`
2. 从 bullseye 起不再提供 ui 仓库