### PR TITLE
更正nix-darwin的文檔

### DIFF
--- a/source/nix-channels.rst
+++ b/source/nix-channels.rst
@@ -51,7 +51,7 @@ NixOS channel 也可以以类似命令替换，以 ``nixos-19.09`` 为例（需�
 
 ::
 
-    nix.binaryCaches = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
+    nix.settings.substituters = [ "https://mirrors.ustc.edu.cn/nix-channels/store" ];
 
 对于 NixOS 21.11 及之前的版本，在 ``/etc/nixos/configuration.nix`` 中添加：
 


### PR DESCRIPTION
[上游: Many options moved/renamed from `nix.*` to `nix.settings.*`. For example
  `nix.binaryCaches` is now `nix.settings.substituters`.
](https://github.com/LnL7/nix-darwin/blob/bcc8afd06e237df060c85bad6af7128e05fd61a3/CHANGELOG#L34-L35)