### PR TITLE
mozilla - limit arch to amd64 only

### DIFF
--- a/docs/mozilla.md
+++ b/docs/mozilla.md
@@ -40,7 +40,7 @@ Linux](https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-fire
 4. 添加镜像仓库：
 
     ```shell
-    echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://mirrors.ustc.edu.cn/mozilla/apt mozilla main" | sudo tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://mirrors.ustc.edu.cn/mozilla/apt mozilla main" | sudo tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null
     ```
 
 5. 设置优先级，避免 Ubuntu 下 snap 版本被优先安装：


### PR DESCRIPTION
镜像源里只有amd64，所以`sources.list`里要加一个约束，主要是为了消除找不到i386包这种多余的报错