### PR TITLE
archlinuxarm: fix the link of home page

### DIFF
--- a/docs/archlinuxarm.md
+++ b/docs/archlinuxarm.md
@@ -24,7 +24,7 @@ Server = https://mirrors.ustc.edu.cn/archlinuxarm/$arch/$repo
 
 官方主页
 
-:   <https://www.archlinuxarm.org/>
+:   <https://archlinuxarm.org/>
 
 论坛
 


### PR DESCRIPTION
The SSL certificate is only valid for the root domain `archlinuxarm.org`, when visiting `www.archlinuxarm.org` you'll get a warning.