### PR TITLE
freebsd-pkg: add mirror_type: "none"

### DIFF
--- a/docs/freebsd-pkg.md
+++ b/docs/freebsd-pkg.md
@@ -27,6 +27,7 @@ FreeBSD pkg 包管理器的官方源配置是 `/etc/pkg/FreeBSD.conf`，请先�
 ```yaml
 FreeBSD: {
   url: "http://mirrors.ustc.edu.cn/freebsd-pkg/${ABI}/quarterly",
+  mirror_type: "none",
 }
 ```
 


### PR DESCRIPTION
Since currently there is no `SRV` record on either `_http._tcp.mirrors.ustc.edu.cn` or `_https._tcp.mirrors.ustc.edu.cn`, the `mirror_type` field in `/etc/pkg/FreeBSD.conf` should be overridden to `none`, otherwise `pkg(8)` may produce warnings like:

> pkg: No SRV record found for the repo 'FreeBSD'

See also: [pkg.conf(5)](https://man.freebsd.org/cgi/man.cgi?pkg.conf(5)), [#90665](https://forums.freebsd.org/threads/90655/), [#90716](https://forums.freebsd.org/threads/90716/)