### PR TITLE
update ghcup.md: inform users of the dependency of ghcup over hackage

### DIFF
--- a/docs/ghcup.md
+++ b/docs/ghcup.md
@@ -11,10 +11,7 @@ Stackage 源使用。
 
 !!! warning
 
-    当前的 GHCup 0.0.8 版本会在安装时也尝试安装 cabal，
-    因此建议在安装 GHCup 前先手动配置 cabal 使用镜像，
-    方法为参考文档 [hackage](https://mirrors.ustc.edu.cn/help/hackage.html#cabal)，
-    修改 `~/.cabal/config`。
+    当前的 GHCup 0.0.8 版本会在安装时也尝试安装 cabal，因此建议在安装 GHCup 前先手动配置 cabal 使用镜像，方法为参考文档 [hackage](https://mirrors.ustc.edu.cn/help/hackage.html#cabal) 中的说明，修改 `~/.cabal/config`。
 
 ## 使用方法
 

--- a/docs/ghcup.md
+++ b/docs/ghcup.md
@@ -23,16 +23,16 @@ Stackage 源使用。
 **第一步（可选）** ：使用科大源安装 GHCup 本体。如已经安装 GHCup，可跳到下一步。
 
     # Linux, FreeBSD, macOS 用户：在终端中运行如下命令
-    curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML=https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.7.yaml sh
+    curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell | BOOTSTRAP_HASKELL_YAML=https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml sh
 
     # Windows 用户：以非管理员身份在 PowerShell 中运行如下命令
-    $env:BOOTSTRAP_HASKELL_YAML = 'https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.7.yaml'
+    $env:BOOTSTRAP_HASKELL_YAML = 'https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml'
     Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest https://mirrors.ustc.edu.cn/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true
 
 **第二步** ：配置 GHCup 使用科大源。编辑 `~/.ghcup/config.yaml` 增加如下配置：
 
     url-source:
-      OwnSource: https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.7.yaml
+      OwnSource: https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
 
 **第三步（可选）** ：配置 Cabal 和 Stack 使用科大源，请参考文档 [hackage](hackage.md) 和 [stackage](stackage.md)。
 
@@ -48,7 +48,7 @@ Stackage 源使用。
 
     url-source:
       OwnSource:
-        - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.7.yaml
+        - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
         - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-prereleases-0.0.7.yaml
 
 ## 相关链接

--- a/docs/ghcup.md
+++ b/docs/ghcup.md
@@ -15,7 +15,7 @@ Stackage 源使用。
 
 !!! note
 
-    以下命令会安装并配置 GHCup 0.0.7 版本的元数据。可查看
+    以下命令会安装并配置 GHCup 0.0.8 版本的元数据。可查看
     <https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/>
     目录的内容，并选择需要安装的 GHCup 版本的 yaml 文件替换以下命令中的
     URL。
@@ -49,7 +49,7 @@ Stackage 源使用。
     url-source:
       OwnSource:
         - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-0.0.8.yaml
-        - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-prereleases-0.0.7.yaml
+        - https://mirrors.ustc.edu.cn/ghcup/ghcup-metadata/ghcup-prereleases-0.0.8.yaml
 
 ## 相关链接
 

--- a/docs/ghcup.md
+++ b/docs/ghcup.md
@@ -9,6 +9,13 @@
 GHCup 类似 Rustup，可以用于安装 Haskell 工具链。建议搭配 Hackage 和
 Stackage 源使用。
 
+!!! warning
+
+    当前的 GHCup 0.0.8 版本会在安装时也尝试安装Cabal，
+    因此建议在安装GHCup前先手动配置cabal使用镜像，
+    方法为参考文档 [hackage](https://mirrors.ustc.edu.cn/help/hackage.html#:~:text=~/.cabal/config) 中的方法
+    修改 `~/.cabal/config`
+
 ## 使用方法
 
 参考如下步骤可安装完整的 Haskell 工具链。

--- a/docs/ghcup.md
+++ b/docs/ghcup.md
@@ -11,10 +11,10 @@ Stackage 源使用。
 
 !!! warning
 
-    当前的 GHCup 0.0.8 版本会在安装时也尝试安装Cabal，
-    因此建议在安装GHCup前先手动配置cabal使用镜像，
-    方法为参考文档 [hackage](https://mirrors.ustc.edu.cn/help/hackage.html#:~:text=~/.cabal/config) 中的方法
-    修改 `~/.cabal/config`
+    当前的 GHCup 0.0.8 版本会在安装时也尝试安装 cabal，
+    因此建议在安装 GHCup 前先手动配置 cabal 使用镜像，
+    方法为参考文档 [hackage](https://mirrors.ustc.edu.cn/help/hackage.html#cabal)，
+    修改 `~/.cabal/config`。
 
 ## 使用方法
 


### PR DESCRIPTION
当前版本的ghcup在安装时也会安装cabal，而如果只按照原本文档的内容做，此时的cabal并没有被设置科大镜像，因此会直接从官方网站走，下载量约100M，且没有很好的进度提示；

解决方案是按照hackage帮助中的内容设置cabal镜像；

我建议在ghcup的帮助中，建议读者阅读cabal镜像的帮助，并设置cabal镜像的代理；这部分文档的调整已经在这个PR中完成；
但是否采取这一方案，或是要重新组织文档的顺序，我认为有待讨论。