### PR TITLE
openeuler: update sed command to handle HTTPS URLs

### DIFF
--- a/docs/openeuler.md
+++ b/docs/openeuler.md
@@ -25,8 +25,7 @@ x86_64, aarch64
 使用以下命令替换默认配置
 
 ```shell
-sudo sed -e 's|http://repo.openeuler.org/|https://mirrors.ustc.edu.cn/openeuler/|g' \
-         -e 's|https://mirrors.openeuler.org/|https://mirrors.ustc.edu.cn/openeuler/|g' \
+sudo sed -E 's#https?://(repo|mirrors)\.openeuler\.org/#https://mirrors.ustc.edu.cn/openeuler/#g' \
          -i.bak \
          /etc/yum.repos.d/openEuler.repo
 ```


### PR DESCRIPTION
在 openEuler 22.03 (LTS-SP4) 或更早版本上，`repo.openeuler.org` 开始使用 https 协议。  
此 pr 修改了帮助文档中的 sed 命令，使其能够处理 `{http, https}://{repo, mirrors}.openeuler.org` 。  

<img width="646" alt="{ADFB57D1-F96E-4225-9F8B-754B1F271C1A}" src="https://github.com/user-attachments/assets/d3920db2-5762-438d-bb81-1c90b2209343" />
<img width="702" alt="{8EBB4D4D-4A20-4EA1-8F5C-568E2597CF8E}" src="https://github.com/user-attachments/assets/a4f4de60-ee25-4dc5-8350-2dc0b99c8070" />
