### PR TITLE
Update FreeBSD docs for improved clarity and HTTPS

### DIFF
--- a/docs/freebsd-pkg.md
+++ b/docs/freebsd-pkg.md
@@ -12,28 +12,38 @@ FreeBSD 预编译软件包镜像
 
 所有受官方支持版本的 amd64 和 aarch64 架构，详细参见 <https://pkg.freebsd.org/>。
 
-仓库包括 quarterly 和滚动更新的 latest 仓库。
+仓库包括季度分支 quarterly 和滚动更新的 latest 仓库。
+
+!!! tip
+
+    并非所有版本和架构都同时拥有 quarterly 或 latest 仓库，如 CURRENT 仅有 latest。
 
 ## 使用方法
 
-FreeBSD pkg 包管理器的官方源配置是 `/etc/pkg/FreeBSD.conf`，请先检查该文件内容。注意其中的 `url` 参数配置了官方仓库的地址，我们需要把它替换为镜像站的地址。
+!!! warning
 
-该配置文件是 FreeBSD 基本系统的一部分，会随着 `freebsd-update` 更新，请不要直接修改，而是创建 `/usr/local/etc/pkg/repos/FreeBSD.conf` 覆盖配置，文件内容如下：
+    在操作前请做好相应备份。
 
-```yaml
-FreeBSD: {
-  url: "http://mirrors.ustc.edu.cn/freebsd-pkg/${ABI}/quarterly",
-  mirror_type: "none",
+为了避免可能出现的向后兼容问题，基本系统中未预置真实的 pkg(8) 工具，需要在线安装。参见 [man pkg(7)](https://man.freebsd.org/cgi/man.cgi?query=pkg)。安装方法为直接输入命令 `pkg` 根据提示进行确认安装。为了避免因网络问题造成安装失败，建议先按以下方法换源后再安装 pkg。
+
+FreeBSD pkg 包管理器的官方源的配置路径为 `/etc/pkg/FreeBSD.conf`。不建议直接修改此文件：该配置文件是 FreeBSD 基本系统的一部分，会随着基本系统的更新而变化。
+
+应创建路径及文件 `/usr/local/etc/pkg/repos/USTC.conf` 来覆盖配置，文件内容如下：
+
+```ini
+ustc: {
+url: "https://mirrors.ustc.edu.cn/freebsd-pkg/${ABI}/quarterly",
 }
+FreeBSD: { enabled: no }
 ```
 
-如果要使用滚动更新的 latest 仓库，把 `url` 配置最后的 `quarterly` 换成 `latest` 即可。
+若要使用滚动更新的 latest 仓库，将 `url` 这行配置末尾的 `quarterly` 换成 `latest` 即可。
 
 修改配置后，运行 `pkg update -f` 更新索引。
 
 !!! tip
 
-    使用 HTTPS 可以有效避免国内运营商的缓存劫持，但早于 13.2-RELEASE 的系统版本需要事先安装 `security/ca_root_nss` 软件包。
+    如未配置 [pkgbase](https://wiki.freebsd.org/pkgbase)，则 pkg 仅管理用户安装的第三方软件（Port），无法更新基本系统。基本系统与通过 pkg 安装的软件互不干涉。
 
 ## 相关链接
 
@@ -41,10 +51,22 @@ FreeBSD: {
 
 :   <https://www.freebsd.org>
 
+邮件列表
+
+:   <https://www.freebsd.org/community/mailinglists>
+
 论坛
 
 :   <https://forums.freebsd.org>
 
 文档
 
-:   <https://www.freebsd.org/doc>
+:   <https://docs.freebsd.org>
+
+WiKi
+
+:   <https://wiki.freebsd.org>
+
+官方 Discord
+
+: <https://discord.com/invite/freebsd>

--- a/docs/freebsd-ports.md
+++ b/docs/freebsd-ports.md
@@ -2,7 +2,7 @@
 
 ## 地址
 
-<http://mirrors.ustc.edu.cn/freebsd-ports/>
+<https://mirrors.ustc.edu.cn/freebsd-ports/>
 
 ## 说明
 
@@ -12,11 +12,15 @@ FreeBSD ports 软件源
 
 在 `/etc/make.conf` 中添加以下内容（如果文件不存在，则新建之）：
 
-    MASTER_SITE_OVERRIDE?=http://mirrors.ustc.edu.cn/freebsd-ports/distfiles/${DIST_SUBDIR}/
+    MASTER_SITE_OVERRIDE?=https://mirrors.ustc.edu.cn/freebsd-ports/distfiles/${DIST_SUBDIR}/
 
 ports.tar.gz 文件为 Ports Collection，可以下载后解压到 `/usr/ports/` 目录。也可参考 FreeBSD Handbook 中 [Installing the Ports Collection](https://docs.freebsd.org/en/books/handbook/ports/#ports-using-installation-methods) 一节，使用 `git` 获取 ports tree：
 
     git clone --filter=tree:0 https://mirrors.ustc.edu.cn/freebsd-ports/ports.git /usr/ports
+
+!!! tip
+    
+	FreeBSD 基本系统并未预置 git，需要自行安装 Port devel/git。
 
 !!! warning
 
@@ -25,22 +29,22 @@ ports.tar.gz 文件为 Ports Collection，可以下载后解压到 `/usr/ports/`
     方式及其注意事项，可参考
     [GitHub Blog 的有关文章](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)。
 
-    本帮助早期版本使用了 `--depth`，但请**避免**使用 `--depth` 参数，
+    本帮助早期版本使用了 `--depth`，但请 **避免** 使用 `--depth` 参数，
     因为其后续更新会给服务器带来大量的计算压力。
 
     如果不需要后续更新 ports，推荐直接下载
-    <http://mirrors.ustc.edu.cn/freebsd-ports/ports.tar.gz> 文件并解压。
+    <https://mirrors.ustc.edu.cn/freebsd-ports/ports.tar.gz> 文件并解压。
 
 !!! warning
 
     部分 ports 的源代码需要从
     <http://distcache.freebsd.org/ports-distfiles/> 以外的 master site
-    下载，本镜像不包含这些文件。
+    下载，本镜像未包含这些文件。
 
 !!! warning
 
     本镜像仅包含 ports tree 中 HEAD branch 引用到的文件。季度分支（如
-    `2020Q4`）引用的文件有可能不包含在本镜像中。
+    `2024Q4`）引用的文件有可能未被包含于本镜像中。
 
 ## 相关链接
 
@@ -48,14 +52,22 @@ ports.tar.gz 文件为 Ports Collection，可以下载后解压到 `/usr/ports/`
 
 :   <https://www.freebsd.org>
 
+邮件列表
+
+:   <https://www.freebsd.org/community/mailinglists>
+
 论坛
 
 :   <https://forums.freebsd.org>
 
 文档
 
-:   <https://www.freebsd.org/doc>
+:   <https://docs.freebsd.org>
 
-官方介绍
+WiKi
 
-:   <https://www.freebsd.org/ports>
+:   <https://wiki.freebsd.org>
+
+官方 Discord
+
+: <https://discord.com/invite/freebsd>

--- a/docs/freebsd.md
+++ b/docs/freebsd.md
@@ -18,11 +18,20 @@ FreeBSD 支持的所有正式版本
 
 ## 使用说明
 
-- ISO 镜像位于
-    [/releases/ISO-IMAGES](http://mirrors.ustc.edu.cn/freebsd/releases/ISO-IMAGES)
+- ISO/IMG 镜像位于
+    [/releases/ISO-IMAGES](https://mirrors.ustc.edu.cn/freebsd/releases/ISO-IMAGES)
 - 虚拟机模板位于
-    [/releases/VM-IMAGES](http://mirrors.ustc.edu.cn/freebsd/releases/VM-IMAGES)
-- 文档及资料位于 [/doc](http://mirrors.ustc.edu.cn/freebsd/doc)
+    [/releases/VM-IMAGES](https://mirrors.ustc.edu.cn/freebsd/releases/VM-IMAGES)
+- OCI 镜像位于
+    [/releases/OCI-IMAGES](https://mirrors.ustc.edu.cn/freebsd/releases/OCI-IMAGES)
+- CI 镜像位于
+    [/releases/CI-IMAGES](https://mirrors.ustc.edu.cn/freebsd/releases/CI-IMAGES)
+- 文档及资料位于 
+    [/doc](https://mirrors.ustc.edu.cn/freebsd/doc)
+	
+!!! warning
+
+    FreeBSD 的 STABLE 镜像是开发版本，并非一般发行版意义上的“稳定版”，仅代表此大版本内 ABI 稳定，FreeBSD 官方不建议将其应用于生产环境。参见 [FreeBSD Glossary STABLE](https://wiki.freebsd.org/Glossary#STABLE)。FreeBSD 传统意义上的稳定版是 RELEASE，FreeBSD 官方推荐将其用于生成环境。FreeBSD 的主线（main）开发版本称作 CURRENT。参见 [FreeBSD Release Engineering](https://docs.freebsd.org/en/articles/freebsd-releng/)。
 
 !!! warning
 
@@ -39,10 +48,22 @@ FreeBSD 支持的所有正式版本
 
 :   <https://www.freebsd.org>
 
+邮件列表
+
+:   <https://www.freebsd.org/community/mailinglists>
+
 论坛
 
 :   <https://forums.freebsd.org>
 
 文档
 
-:   <https://www.freebsd.org/doc>
+:   <https://docs.freebsd.org>
+
+WiKi
+
+:   <https://wiki.freebsd.org>
+
+官方 Discord
+
+: <https://discord.com/invite/freebsd>


### PR DESCRIPTION
为 FreeBSD 的 pkg 和 ports 镜像提供了增强的文档，明确了配置步骤，将 URL 更新为使用 HTTPS，增加了提示与警告，并扩展了相关链接（包括邮件列表、Wiki 和 Discord）。同时在 FreeBSD 主文档中进一步明确了 STABLE 与 RELEASE 版本的区别。

由于内核模块源和 pkgbase 仍未落地（14.3 已引入内核模块源，但是也许需要等待看 15.0 的处理方案），FreeBSD 项目仍在考虑，故未提及。根据源代码团队[会议纪要](https://github.com/freebsd/meetings/pull/22)，pkgbase 目前的意图似乎通过传统的更新工具 `freebsd-update`  来调用，而非之前的通过 pkg 命令调用。