### PR TITLE
archlinux: update mailing list URL

### DIFF
--- a/docs/archlinux.md
+++ b/docs/archlinux.md
@@ -30,7 +30,7 @@ Server = https://mirrors.ustc.edu.cn/archlinux/$repo/os/$arch
 
 邮件列表
 
-:   <https://www.archlinux.org/mailman/listinfo/>
+:   <https://lists.archlinux.org/mailman3/lists/>
 
 论坛
 


### PR DESCRIPTION
The Arch Linux mailing list URL currently returns a 404 (Page Not Found).